### PR TITLE
Update feature_flags_api.rb to support semantic patches on a feature flag

### DIFF
--- a/lib/launchdarkly_api/api/feature_flags_api.rb
+++ b/lib/launchdarkly_api/api/feature_flags_api.rb
@@ -920,9 +920,9 @@ module LaunchDarklyApi
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
-      content_type = @api_client.select_header_content_type(['application/json'])
-      if !content_type.nil?
-          header_params['Content-Type'] = content_type
+      unless header_params['Content-Type']
+        content_type = @api_client.select_header_content_type(['application/json'])
+        header_params['Content-Type'] = content_type if content_type
       end
 
       # form parameters


### PR DESCRIPTION
patch_feature_flag_with_http_info was overwriting custom 'Content-Type' header used for semantic patches on a feature flag.

- Added a conditional check to ensure 'Content-Type' header is only set if it is not already present in `header_params`.
- This prevents overwriting an existing 'Content-Type' header value